### PR TITLE
[Feat]  다이어리 캘린더 및 AI 보관함 조회 API 구현 (Query 분리)

### DIFF
--- a/src/main/java/com/example/petlog/controller/DiaryQueryController.java
+++ b/src/main/java/com/example/petlog/controller/DiaryQueryController.java
@@ -1,0 +1,35 @@
+package com.example.petlog.controller;
+
+import com.example.petlog.dto.response.DiaryResponse;
+import com.example.petlog.service.DiaryQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/diary-queries")
+@RequiredArgsConstructor
+public class DiaryQueryController {
+
+    private final DiaryQueryService diaryQueryService;
+
+    // === 캘린더 날짜별 조회 API ===
+    // GET /api/diaries/calendar?userId=1&date=2024-03-01
+    @GetMapping("/calendar")
+    public ResponseEntity<List<DiaryResponse>> getDiariesByDate(
+            @RequestParam Long userId,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {
+        return ResponseEntity.ok(diaryQueryService.getDiariesByDate(userId, date));
+    }
+
+    // === AI 다이어리 보관함 조회 API ===
+    // GET /api/diaries/ai-archive?userId=1
+    @GetMapping("/ai-archive")
+    public ResponseEntity<List<DiaryResponse>> getAiDiaries(@RequestParam Long userId) {
+        return ResponseEntity.ok(diaryQueryService.getAiDiaries(userId));
+    }
+}

--- a/src/main/java/com/example/petlog/dto/response/DiaryResponse.java
+++ b/src/main/java/com/example/petlog/dto/response/DiaryResponse.java
@@ -25,11 +25,13 @@ public class DiaryResponse {
     private Visibility visibility;
     private String weather;
     private String mood;
+    private Boolean isAiGen; // AI 여부 확인용
     private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
 
     private List<Image> images;
 
-    // Entity -> DTO 변환 (메서드명 변경: from -> fromEntity)
+    // [핵심] Entity -> DTO 변환 로직 (Service에서 호출)
     public static DiaryResponse fromEntity(Diary diary) {
         return DiaryResponse.builder()
                 .diaryId(diary.getDiaryId())
@@ -39,7 +41,9 @@ public class DiaryResponse {
                 .visibility(diary.getVisibility())
                 .weather(diary.getWeather())
                 .mood(diary.getMood())
+                .isAiGen(diary.getIsAiGen())
                 .createdAt(diary.getCreatedAt())
+                .updatedAt(diary.getUpdatedAt())
                 .images(diary.getImages().stream()
                         .map(Image::fromEntity)
                         .collect(Collectors.toList()))

--- a/src/main/java/com/example/petlog/repository/DiaryQueryRepository.java
+++ b/src/main/java/com/example/petlog/repository/DiaryQueryRepository.java
@@ -1,0 +1,18 @@
+package com.example.petlog.repository;
+
+import com.example.petlog.entity.Diary;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Repository
+public interface DiaryQueryRepository extends JpaRepository<Diary, Long> {
+
+    // 1. 캘린더용 날짜별 조회 (해당 날짜의 00:00:00 ~ 23:59:59 사이 데이터 검색)
+    List<Diary> findAllByUserIdAndCreatedAtBetween(Long userId, LocalDateTime start, LocalDateTime end);
+
+    // 2. AI 다이어리 보관함 조회 (isAiGen = true 인 것만)
+    List<Diary> findAllByUserIdAndIsAiGenOrderByCreatedAtDesc(Long userId, Boolean isAiGen);
+}

--- a/src/main/java/com/example/petlog/service/DiaryQueryService.java
+++ b/src/main/java/com/example/petlog/service/DiaryQueryService.java
@@ -1,0 +1,15 @@
+package com.example.petlog.service;
+
+import com.example.petlog.dto.response.DiaryResponse;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface DiaryQueryService {
+
+    // 캘린더용: 특정 날짜의 일기 조회
+    List<DiaryResponse> getDiariesByDate(Long userId, LocalDate date);
+
+    // 보관함용: AI 다이어리 전체 조회
+    List<DiaryResponse> getAiDiaries(Long userId);
+}

--- a/src/main/java/com/example/petlog/service/impl/DiaryQueryServiceImpl.java
+++ b/src/main/java/com/example/petlog/service/impl/DiaryQueryServiceImpl.java
@@ -1,0 +1,45 @@
+package com.example.petlog.service.impl;
+
+import com.example.petlog.dto.response.DiaryResponse;
+import com.example.petlog.entity.Diary;
+import com.example.petlog.repository.DiaryQueryRepository;
+import com.example.petlog.service.DiaryQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class DiaryQueryServiceImpl implements DiaryQueryService {
+
+    private final DiaryQueryRepository diaryQueryRepository;
+
+    @Override
+    public List<DiaryResponse> getDiariesByDate(Long userId, LocalDate date) {
+        LocalDateTime startOfDay = date.atStartOfDay();
+        LocalDateTime endOfDay = date.atTime(LocalTime.MAX);
+
+        List<Diary> diaries = diaryQueryRepository.findAllByUserIdAndCreatedAtBetween(userId, startOfDay, endOfDay);
+
+        return diaries.stream()
+                .map(DiaryResponse::fromEntity)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<DiaryResponse> getAiDiaries(Long userId) {
+        // isAiGen = true 인 데이터만 조회하도록 호출
+        List<Diary> aiDiaries = diaryQueryRepository.findAllByUserIdAndIsAiGenOrderByCreatedAtDesc(userId, true);
+
+        return aiDiaries.stream()
+                .map(DiaryResponse::fromEntity)
+                .collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
## ⚡️ 관련 이슈
Closes #7 

---

## 🐰 작업 내용
다이어리 조회 기능을 확장하고, 유지보수성을 위해 조회 전용 로직을 분리

1. 다이어리 조회 API 확장

- 캘린더 날짜별 조회: 사용자가 선택한 날짜(yyyy-MM-dd)에 작성된 일기 목록을 조회하는 API 구현 (/api/diary-queries/calendar)

- AI 보관함 조회: AI가 생성해준(isAiGen=true) 다이어리만 모아볼 수 있는 보관함 조회 API 구현 (/api/diary-queries/ai-archive)

2. Command/Query 분리 (CQRS 패턴 적용)

- 기존 DiaryService와 DiaryRepository에 혼재되어 있던 복잡한 조회 로직을 분리

- DiaryQueryController, DiaryQueryService, DiaryQueryRepository 신설하여 조회 전담 구조 구축

- **단일 테이블 활용**: 조회 로직은 분리되었으나 물리적으로는 기존 Diary 테이블(Entity)을 직접 조회하도록 구성하여, 별도의 데이터 동기화 없이 실시간 데이터 일관성 유지

---

##  🔥 테스트 결과
- [x] Postman 테스트 완료

GET /calendar: 특정 날짜의 일기 데이터(일반/AI 포함)가 정상적으로 조회됨 확인

GET /ai-archive: isAiGen=true인 데이터만 필터링되어 조회됨 확인

- [ ] 통합 테스트(JUnit) 통과

DiaryQueryIntegrationTest: 데이터 생성 후 조건별 조회 테스트 성공

---

## 📸 스크린샷 
<img width="1075" height="114" alt="스크린샷 2025-12-03 오후 4 26 00" src="https://github.com/user-attachments/assets/19e24819-b14c-4990-9190-d192512f3f16" />
<img width="723" height="471" alt="스크린샷 2025-12-03 오후 4 12 40" src="https://github.com/user-attachments/assets/4988775e-3bcc-43ad-98a7-6777623dca3f" />

---

<img width="752" height="719" alt="스크린샷 2025-12-03 오후 4 13 06" src="https://github.com/user-attachments/assets/51567800-5dd1-4627-9be2-13b92658a188" />

---
<img width="749" height="498" alt="스크린샷 2025-12-03 오후 4 13 38" src="https://github.com/user-attachments/assets/0fd453ea-c573-440c-8885-a272452c049b" />

---

## 💬 리뷰 요구사항
1. 조회 로직 분리 구조 (CQRS)

복잡한 조회가 늘어날 것을 대비해 QueryService와 QueryRepository를 분리했습니다. 이 구조가 적절한지 피드백 부탁드립니다.

2. 날짜 조회 쿼리

LocalDate를 받아 atStartOfDay()와 atTime(LocalTime.MAX)로 변환하여 Between 검색을 수행했습니다. 타임존(Timezone) 이슈 없이 의도대로 동작할지 확인 부탁드립니다.

ex)
- atStartOfDay(): 그 날의 시작 (00:00:00)

- atTime(LocalTime.MAX): 그 날의 끝 (23:59:59.999999999)