### PR TITLE
[Feat] 회원 서비스(User/Pet) 연동 및 다이어리 생성 시 유효성 검증 로직 구현

### DIFF
--- a/src/main/java/com/petlog/record/client/MockPetServiceClient.java
+++ b/src/main/java/com/petlog/record/client/MockPetServiceClient.java
@@ -1,0 +1,40 @@
+package com.petlog.record.client;
+
+import com.petlog.record.dto.client.PetClientResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+@Slf4j
+@Component
+@Primary // [중요] 실제 FeignClient 대신 이 빈을 우선적으로 주입함
+@Profile({"test", "local-test"}) // 로컬 테스트 환경에서만 활성화
+public class MockPetServiceClient implements PetServiceClient {
+
+    @Override
+    public Boolean checkPetExists(Long petId) {
+        log.info("[Mock] PetServiceClient: 펫 존재 여부 확인 요청 (petId={}) -> true 반환", petId);
+        // 테스트를 위해 무조건 true 반환 (실제 서버 통신 X)
+        return true;
+    }
+
+    @Override
+    public PetClientResponse getPetInfo(Long petId) {
+        log.info("[Mock] PetServiceClient: 펫 정보 조회 요청 (petId={})", petId);
+        return PetClientResponse.builder()
+                .petId(petId)
+                .petName("바둑이")
+                .breed("말티즈")
+                .age(3)
+                .genderType("MALE")
+                .isNeutered(true)
+                .status("ACTIVE")
+                .profileImage("https://mock-url.com/pet.jpg")
+                .birth(LocalDateTime.now())
+                .species("DOG")
+                .build();
+    }
+}

--- a/src/main/java/com/petlog/record/client/MockUserServiceClient.java
+++ b/src/main/java/com/petlog/record/client/MockUserServiceClient.java
@@ -1,0 +1,33 @@
+package com.petlog.record.client;
+
+import com.petlog.record.dto.client.UserClientResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@Primary // [중요] 실제 FeignClient 대신 이 빈을 우선적으로 주입함
+@Profile({"test", "local-test"}) // 로컬 테스트 환경에서만 활성화
+public class MockUserServiceClient implements UserServiceClient {
+
+    @Override
+    public Boolean checkUserExists(Long userId) {
+        log.info("[Mock] UserServiceClient: 사용자 존재 여부 확인 요청 (userId={}) -> true 반환", userId);
+        // 테스트를 위해 무조건 true 반환 (실제 서버 통신 X)
+        return true;
+    }
+
+    @Override
+    public UserClientResponse getUserInfo(Long userId) {
+        log.info("[Mock] UserServiceClient: 사용자 정보 조회 요청 (userId={})", userId);
+        return UserClientResponse.builder()
+                .username("테스트유저")
+                .genderType("MALE")
+                .age(25)
+                .profileImage("https://mock-url.com/profile.jpg")
+                .statusMessage("테스트 중입니다.")
+                .build();
+    }
+}

--- a/src/main/java/com/petlog/record/client/PetServiceClient.java
+++ b/src/main/java/com/petlog/record/client/PetServiceClient.java
@@ -1,12 +1,22 @@
 package com.petlog.record.client;
 
+import com.petlog.record.dto.client.PetClientResponse;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 
-// Pet Service 호출
 @FeignClient(name = "pet-service", url = "${external.pet-service.url}")
 public interface PetServiceClient {
+
+    /**
+     * 펫 존재 여부 확인
+     */
     @GetMapping("/api/pets/{petId}/exists")
-    boolean checkPetExists(@PathVariable("petId") Long petId);
+    Boolean checkPetExists(@PathVariable("petId") Long petId);
+
+    /**
+     * 펫 상세 정보 조회
+     */
+    @GetMapping("/api/pets/{petId}")
+    PetClientResponse getPetInfo(@PathVariable("petId") Long petId);
 }

--- a/src/main/java/com/petlog/record/client/UserServiceClient.java
+++ b/src/main/java/com/petlog/record/client/UserServiceClient.java
@@ -1,12 +1,22 @@
 package com.petlog.record.client;
 
+import com.petlog.record.dto.client.UserClientResponse;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 
-// User Service 호출
 @FeignClient(name = "user-service", url = "${external.user-service.url}")
 public interface UserServiceClient {
+
+    /**
+     * 사용자 존재 여부 확인
+     */
     @GetMapping("/api/users/{userId}/exists")
-    boolean checkUserExists(@PathVariable("userId") Long userId);
+    Boolean checkUserExists(@PathVariable("userId") Long userId);
+
+    /**
+     * 사용자 상세 정보 조회
+     */
+    @GetMapping("/api/users/{userId}")
+    UserClientResponse getUserInfo(@PathVariable("userId") Long userId);
 }

--- a/src/main/java/com/petlog/record/dto/client/PetClientResponse.java
+++ b/src/main/java/com/petlog/record/dto/client/PetClientResponse.java
@@ -1,0 +1,32 @@
+package com.petlog.record.dto.client;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PetClientResponse {
+
+    // PetResponse.GetPetDto 구조에 맞춤
+    private Long petId;
+
+    private String petName;         // 펫 이름
+    private String species;         // 종류 (Enum -> String)
+    private String breed;           // 품종
+    private String genderType;      // 성별 (Enum -> String)
+
+    @JsonProperty("is_neutered")    // JSON 필드명 매핑 (is_neutered)
+    private boolean isNeutered;     // 중성화 여부
+
+    private String profileImage;    // 프로필 사진
+    private Integer age;            // 나이
+    private LocalDateTime birth;    // 생일
+    private String status;          // 상태 (Enum -> String)
+}

--- a/src/main/java/com/petlog/record/dto/client/UserClientResponse.java
+++ b/src/main/java/com/petlog/record/dto/client/UserClientResponse.java
@@ -1,0 +1,25 @@
+package com.petlog.record.dto.client;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserClientResponse {
+
+    // UserResponse.GetUserDto 구조에 맞춤
+    private String username;        // 사용자 이름(닉네임)
+    private String genderType;      // 성별 (Enum -> String)
+    private String profileImage;    // 프로필 사진
+    private String statusMessage;   // 상태메세지
+    private Integer age;            // 나이
+
+    // 필요 시 추가 (GetUserDto에 있는 나머지 필드)
+    // private Integer currentLat;
+    // private Integer currentLng;
+    // private Long petCoin;
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -41,7 +41,7 @@ server:
 # === 외부 서비스 URL 설정 (Default Profile) ===
 external:
   user-service:
-    url: ${USER_SERVICE_URL }
+    url: ${USER_SERVICE_URL}
   pet-service:
     url: ${PET_SERVICE_URL}
   notification-service:
@@ -61,7 +61,8 @@ springdoc:
 spring:
   config:
     activate:
-      on-profile: local-test
+      # on-profile: local-test
+      on-profile:
   cloud:
     openfeign:
       client:


### PR DESCRIPTION
## 🔗 관련 이슈

Closes #20 

---

## 📝 작업 내용

다이어리 서비스와 회원 서비스 간의 연동 구조를 개선하고, 데이터 무결성을 위해 다이어리 생성 시 유효성 검증 로직을 추가했습니다.

1. Feign Client 분리 및 구현

- 기존의 통합된 MemberServiceClient를 도메인별로 분리하여 **UserServiceClient**와 **PetServiceClient**로 재정의했습니다.

- 각 클라이언트에서 상세 정보 조회(getUserInfo, getPetInfo) API를 호출하도록 구현했습니다.
<br>

2. 다이어리 생성 시 유효성 검증 로직 추가 (DiaryServiceImpl)

- createDiary 메서드 진입 시, 요청받은 userId와 petId가 실제 존재하는지 회원 서비스에 질의합니다.

- 구현 방식 (우회 처리): 현재 회원 서비스에 존재 여부 확인(exists) 전용 API가 부재하여, 상세 조회 API(getInfo)를 호출하고 예외 발생 여부(FeignException)로 존재성을 판단하도록 구현했습니다.

- 검증 성공 시 로그를 남기고, 실패(404 등) 시 EntityNotFoundException을 발생시켜 생성을 중단합니다.

<br>

3. 조회 로직 최적화

- DiaryResponse가 상세 객체 대신 ID(userId, petId)만 반환하도록 변경됨에 따라, getDiary 메서드에서 불필요한 회원 서비스 호출 로직을 제거하여 조회 성능을 높였습니다.

---

## ✅ 테스트 결과

- [x] 성공 케이스: 존재하는 userId: 1, petId: 1로 요청 시 정상적으로 다이어리 생성 및 "회원 서비스 연동 성공" 로그 출력 확인.

- [x] 실패 케이스: 존재하지 않는 userId: 2나 petId: 2로 요청 시 404 응답 수신 및 EntityNotFoundException 발생 확인.


---

## 📸 스크린샷

### **회원 및 펫 생성**

<img width="731" height="466" alt="스크린샷 2025-12-12 오전 10 50 33" src="https://github.com/user-attachments/assets/48a16927-ca35-4c0f-970a-c8f287562a31" />
<img width="726" height="615" alt="스크린샷 2025-12-12 오전 10 51 09" src="https://github.com/user-attachments/assets/01e8182c-9540-4661-8a7e-1117941ba3c0" />


### **다이어리 생성**

<img width="731" height="587" alt="다이어리생성" src="https://github.com/user-attachments/assets/e15ed53a-df69-43f0-beb4-8e0562905d66" />

### **실패 케이스**

<img width="732" height="443" alt="스크린샷 2025-12-12 오전 10 52 26" src="https://github.com/user-attachments/assets/73552ad0-396f-49f5-8afd-9fea9218e5c3" />

<img width="735" height="447" alt="스크린샷 2025-12-12 오전 10 52 45" src="https://github.com/user-attachments/assets/48b04744-a4cc-4122-8f42-8d7c0754250f" />

### **서버 로그**
<img width="1051" height="109" alt="스크린샷 2025-12-12 오전 10 54 57" src="https://github.com/user-attachments/assets/b85ee667-fff8-44c3-94c3-903c3bc17ee9" />

---

## 💬 리뷰 요구사항 (Review Points)

- createDiary 내부의 try-catch 블록을 통한 Feign 예외 처리 방식이 적절한지 검토 부탁드립니다.

- MockPetServiceClient 등을 활용한 로컬 테스트 설정이 local-test 프로필에서 정상 작동하는지 확인 부탁드립니다.