### PR TITLE
[FEAT] Kafka 도입 및 다이어리 이벤트 발행(비동기) 로직 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,10 +58,14 @@ dependencies {
     // Spring Boot Starters
     // ========================================
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    // ✅ 추가: application.yml에 MongoDB 설정이 있으므로 의존성 주입이 필요합니다.
+    implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-security'
+    // ✅ 추가: 애플리케이션 상태(Kafka 연결 상태 등) 모니터링을 위해 추천합니다.
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
 
     // ========================================
@@ -87,7 +91,7 @@ dependencies {
     // ========================================
     // Database & GIS
     // ========================================
-    implementation 'org.hibernate.orm:hibernate-spatial:6.6.33.Final'
+    implementation 'org.hibernate.orm:hibernate-spatial:6.6.3.Final'
     implementation 'org.locationtech.jts:jts-core:1.19.0'
     runtimeOnly 'org.postgresql:postgresql'
     runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
@@ -99,9 +103,11 @@ dependencies {
     runtimeOnly 'io.netty:netty-resolver-dns-native-macos:4.1.101.Final:osx-x86_64'   // Intel Mac
 
     // ========================================
-    // Utility
+    // Utility & Env Configuration
     // ========================================
+    // ✅ 추가: 별도 코드 작성 없이 .env 파일을 Spring Environment에 자동으로 주입합니다.
     implementation 'me.paulschwarz:spring-dotenv:4.0.0'
+
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.5'
 
 services:
-  # 1. PostgreSQL + PostGIS
+  # 1. PostgreSQL + PostGIS (RDB)
   postgres:
     image: postgis/postgis:15-3.4-alpine
     container_name: petlog_pg_master
@@ -18,7 +18,7 @@ services:
     networks:
       - petlog-net
 
-  # 2. Milvus - etcd
+  # 2.  Milvus 인프라 - etcd
   etcd:
     container_name: milvus-etcd
     image: quay.io/coreos/etcd:v3.5.0
@@ -30,7 +30,7 @@ services:
     networks:
       - petlog-net
 
-  # 3. Milvus - MinIO
+  # 3. Milvus 인프라 - MinIO
   minio:
     container_name: milvus-minio
     image: minio/minio:RELEASE.2020-12-03T00-03-10Z
@@ -48,7 +48,7 @@ services:
     networks:
       - petlog-net
 
-  # 4. Milvus - Standalone
+  # 4. Milvus - Standalone (Vector DB)
   standalone:
     container_name: milvus-standalone
     image: milvusdb/milvus:v2.3.0
@@ -66,7 +66,7 @@ services:
     networks:
       - petlog-net
 
-  # 5. Attu (Milvus GUI)
+  # 5. Attu (Milvus GUI - http://localhost:8010)
   attu:
     container_name: milvus-attu
     image: zilliz/attu:latest
@@ -79,9 +79,10 @@ services:
     networks:
       - petlog-net
 
-  # 6. Zookeeper
+  # 6. Zookeeper (Kafka용)
   zookeeper:
     image: confluentinc/cp-zookeeper:7.5.0
+    platform: linux/arm64  # ✅ M3 Mac용
     container_name: diary_zookeeper
     restart: always
     ports:
@@ -89,61 +90,68 @@ services:
     environment:
       ZOOKEEPER_CLIENT_PORT: 2181
       ZOOKEEPER_TICK_TIME: 2000
+      ZOOKEEPER_SYNC_LIMIT: 2
+    volumes:
+      - zk_data:/var/lib/zookeeper/data
+      - zk_log:/var/lib/zookeeper/log
+    healthcheck:
+      test: [ "CMD", "bash", "-c", "echo 'ruok' | nc localhost 2181" ]
+      interval: 10s
+      timeout: 5s
+      retries: 3
     networks:
       - petlog-net
+
 
   # ========================================
   # 7. Kafka Broker (핵심 수정 부분)
   # ========================================
   kafka:
     image: confluentinc/cp-kafka:7.5.0
+    platform: linux/arm64  # ✅ M3 Mac용
     container_name: diary_kafka
     restart: always
     depends_on:
       - zookeeper
     ports:
-      - "9092:9092"      # 외부(localhost) 접근용
+      - "19092:19092"      # 외부(localhost) 접근용
       - "29092:29092"    # 내부(컨테이너) 통신용
     environment:
       KAFKA_BROKER_ID: 1
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
 
-      # ✅ 핵심: 두 개의 리스너 설정
-      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092,PLAINTEXT_INTERNAL://0.0.0.0:29092
+      # 리스너 설정
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:29092,PLAINTEXT_HOST://0.0.0.0:19092
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:29092,PLAINTEXT_HOST://localhost:19092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
 
-      # ✅ 외부는 localhost:9092, 내부는 kafka:29092
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092,PLAINTEXT_INTERNAL://kafka:29092
-
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_INTERNAL:PLAINTEXT
-      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT_INTERNAL
-
-      # 로컬 개발 최적화 설정
+      # 로컬 개발 최적화
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
       KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
       KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
       KAFKA_AUTO_CREATE_TOPICS_ENABLE: "true"
-
-      # 성능 최적화
-      KAFKA_NUM_NETWORK_THREADS: 3
-      KAFKA_NUM_IO_THREADS: 8
-
-      # ✅ 로그 설정 (디버깅용)
       KAFKA_LOG_RETENTION_HOURS: 168
       KAFKA_LOG_SEGMENT_BYTES: 1073741824
+
+      # M3 최적화
+      KAFKA_HEAP_OPTS: "-Xmx512M -Xms256M"
     volumes:
       - kafka_data:/var/lib/kafka/data
+    healthcheck:
+      test: ["CMD-SHELL", "kafka-broker-api-versions --bootstrap-server localhost:19092 || exit 1"]
+      interval: 10s
+      timeout: 10s
+      retries: 5
+      start_period: 40s
     networks:
       - petlog-net
-    healthcheck:
-      test: ["CMD-SHELL", "kafka-broker-api-versions --bootstrap-server localhost:9092 || exit 1"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
 
-  # 8. Kafka UI
+  # 8. Kafka UI (http://localhost:8989)
   kafka-ui:
     image: provectuslabs/kafka-ui:latest
+    platform: linux/arm64  # ✅ M3 Mac용
     container_name: diary_kafka_ui
     restart: always
     depends_on:
@@ -167,3 +175,5 @@ volumes:
   milvus_minio:
   milvus_data:
   kafka_data:
+  zk_data:
+  zk_log:

--- a/src/main/java/com/petlog/record/PetlogApplication.java
+++ b/src/main/java/com/petlog/record/PetlogApplication.java
@@ -3,8 +3,9 @@ package com.petlog.record;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.scheduling.annotation.EnableAsync;
 
-
+@EnableAsync
 @EnableFeignClients
 @SpringBootApplication
 public class PetlogApplication {

--- a/src/main/java/com/petlog/record/config/KafkaProducerConfig.java
+++ b/src/main/java/com/petlog/record/config/KafkaProducerConfig.java
@@ -1,74 +1,74 @@
-//package com.petlog.record.config;
-//
-//import com.petlog.record.dto.DiaryEventMessage;
-//import org.apache.kafka.clients.producer.ProducerConfig;
-//import org.apache.kafka.common.serialization.StringSerializer;
-//import org.springframework.beans.factory.annotation.Value;
-//import org.springframework.context.annotation.Bean;
-//import org.springframework.context.annotation.Configuration;
-//import org.springframework.kafka.core.DefaultKafkaProducerFactory;
-//import org.springframework.kafka.core.KafkaTemplate;
-//import org.springframework.kafka.core.ProducerFactory;
-//import org.springframework.kafka.support.serializer.JsonSerializer;
-//
-//import java.util.HashMap;
-//import java.util.Map;
-//
-///**
-// * Kafka Producer 설정
-// *
-// * WHY 필요?
-// * - application.yml보다 세밀한 설정 가능
-// * - 테스트 시 Mock으로 교체 용이
-// *
-// * @author diary-team
-// * @since 2025-12-23
-// */
-//@Configuration
-//public class KafkaProducerConfig {
-//
-//    @Value("${spring.kafka.bootstrap-servers}")
-//    private String bootstrapServers;
-//
-//    /**
-//     * Producer Factory 생성
-//     *
-//     * KafkaTemplate이 사용할 Producer 설정
-//     */
-//    @Bean
-//    public ProducerFactory<String, Object> producerFactory() {
-//        Map<String, Object> config = new HashMap<>();
-//
-//        // Kafka 서버 주소
-//        config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
-//
-//        // Key/Value Serializer
-//        config.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
-//        config.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
-//
-//        // 신뢰성 설정
-//        config.put(ProducerConfig.ACKS_CONFIG, "all");
-//        config.put(ProducerConfig.RETRIES_CONFIG, 3);
-//
-//        // 성능 설정
-//        config.put(ProducerConfig.LINGER_MS_CONFIG, 10);
-//        config.put(ProducerConfig.BATCH_SIZE_CONFIG, 16384);
-//        config.put(ProducerConfig.COMPRESSION_TYPE_CONFIG, "snappy");
-//
-//        return new DefaultKafkaProducerFactory<>(config);
-//    }
-//
-//    /**
-//     * KafkaTemplate Bean
-//     *
-//     * Kafka 메시지 발행에 사용
-//     */
-//    /**
-//     * KafkaTemplate Bean
-//     * DiaryServiceImpl의 Required type인 KafkaTemplate<String, Object>와 일치시킵니다.
-//     */
-//    @Bean
-//    public KafkaTemplate<String, Object> kafkaTemplate() { // ✅ DiaryEventMessage -> Object
-//        return new KafkaTemplate<>(producerFactory());
-//    }
-//}
+package com.petlog.record.config;
+
+import com.petlog.record.dto.DiaryEventMessage;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Kafka Producer 설정
+ *
+ * WHY 필요?
+ * - application.yml보다 세밀한 설정 가능
+ * - 테스트 시 Mock으로 교체 용이
+ *
+ * @author diary-team
+ * @since 2025-12-23
+ */
+@Configuration
+public class KafkaProducerConfig {
+
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
+    /**
+     * Producer Factory 생성
+     *
+     * KafkaTemplate이 사용할 Producer 설정
+     */
+    @Bean
+    public ProducerFactory<String, Object> producerFactory() {
+        Map<String, Object> config = new HashMap<>();
+
+        // Kafka 서버 주소
+        config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+
+        // Key/Value Serializer
+        config.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        config.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+
+        // 신뢰성 설정
+        config.put(ProducerConfig.ACKS_CONFIG, "all");
+        config.put(ProducerConfig.RETRIES_CONFIG, 3);
+
+        // 성능 설정
+        config.put(ProducerConfig.LINGER_MS_CONFIG, 10);
+        config.put(ProducerConfig.BATCH_SIZE_CONFIG, 16384);
+        config.put(ProducerConfig.COMPRESSION_TYPE_CONFIG, "snappy");
+
+        return new DefaultKafkaProducerFactory<>(config);
+    }
+
+    /**
+     * KafkaTemplate Bean
+     *
+     * Kafka 메시지 발행에 사용
+     */
+    /**
+     * KafkaTemplate Bean
+     * DiaryServiceImpl의 Required type인 KafkaTemplate<String, Object>와 일치시킵니다.
+     */
+    @Bean
+    public KafkaTemplate<String, Object> kafkaTemplate() { // ✅ DiaryEventMessage -> Object
+        return new KafkaTemplate<>(producerFactory());
+    }
+}

--- a/src/main/java/com/petlog/record/config/KafkaTopicConfig.java
+++ b/src/main/java/com/petlog/record/config/KafkaTopicConfig.java
@@ -1,0 +1,50 @@
+package com.petlog.record.config;
+
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.TopicBuilder;
+import org.springframework.kafka.core.KafkaAdmin;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Kafka Topic 설정
+ * * WHY 필요?
+ * - 기본적으로 자동 생성되는 토픽은 파티션이 1개임
+ * - 처리량(Throughput) 증대 및 병렬 처리를 위해 파티션을 3개로 명시적 설정
+ */
+@Configuration
+public class KafkaTopicConfig {
+
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
+    public static final String DIARY_EVENTS = "diary-events";
+
+    /**
+     * KafkaAdmin 설정
+     * NewTopic 빈을 읽어 실제 브로커에 토픽을 생성하는 역할
+     */
+    @Bean
+    public KafkaAdmin kafkaAdmin() {
+        Map<String, Object> configs = new HashMap<>();
+        configs.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        return new KafkaAdmin(configs);
+    }
+
+    /**
+     * diary-events 토픽 정의
+     * 파티션 3개, 복제본 1개(로컬) 설정
+     */
+    @Bean
+    public NewTopic diaryEventsTopic() {
+        return TopicBuilder.name(DIARY_EVENTS)
+                .partitions(3)    // 파티션을 3개로 지정
+                .replicas(1)      // 로컬 환경이므로 1로 설정
+                .build();
+    }
+}

--- a/src/main/java/com/petlog/record/controller/DiaryKafkaTestController.java
+++ b/src/main/java/com/petlog/record/controller/DiaryKafkaTestController.java
@@ -1,55 +1,55 @@
-//package com.petlog.record.controller;
-//
-//import com.petlog.record.infrastructure.kafka.DiaryEventProducer;
-//import lombok.RequiredArgsConstructor;
-//import org.springframework.http.ResponseEntity;
-//import org.springframework.web.bind.annotation.*;
-//
-///**
-// * Kafka 테스트용 Controller
-// *
-// * 개발 중에만 사용, 프로덕션에서는 제거
-// *
-// * @author diary-team
-// * @since 2025-12-23
-// */
-//@RestController
-//@RequestMapping("/api/test/kafka")
-//@RequiredArgsConstructor
-//public class DiaryKafkaTestController {
-//
-//    private final DiaryEventProducer diaryEventProducer;
-//
-//    /**
-//     * Kafka 이벤트 발행 테스트
-//     *
-//     * POST /api/test/kafka/publish
-//     * {
-//     *   "diaryId": 1,
-//     *   "userId": 123,
-//     *   "petId": 456,
-//     *   "content": "오늘 산책을 갔어요!",
-//     *   "imageUrl": "https://s3.../image.jpg"
-//     * }
-//     */
-//    @PostMapping("/publish")
-//    public ResponseEntity<String> publishTestEvent(@RequestBody TestEventRequest request) {
-//        diaryEventProducer.publishDiaryCreatedEvent(
-//                request.diaryId(),
-//                request.userId(),
-//                request.petId(),
-//                request.content(),
-//                request.imageUrl()
-//        );
-//
-//        return ResponseEntity.ok("Event published to Kafka!");
-//    }
-//
-//    public record TestEventRequest(
-//            Long diaryId,
-//            Long userId,
-//            Long petId,
-//            String content,
-//            String imageUrl
-//    ) {}
-//}
+package com.petlog.record.controller;
+
+import com.petlog.record.infrastructure.kafka.DiaryEventProducer;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * Kafka 테스트용 Controller
+ *
+ * 개발 중에만 사용, 프로덕션에서는 제거
+ *
+ * @author diary-team
+ * @since 2025-12-23
+ */
+@RestController
+@RequestMapping("/api/test/kafka")
+@RequiredArgsConstructor
+public class DiaryKafkaTestController {
+
+    private final DiaryEventProducer diaryEventProducer;
+
+    /**
+     * Kafka 이벤트 발행 테스트
+     *
+     * POST /api/test/kafka/publish
+     * {
+     *   "diaryId": 1,
+     *   "userId": 123,
+     *   "petId": 456,
+     *   "content": "오늘 산책을 갔어요!",
+     *   "imageUrl": "https://s3.../image.jpg"
+     * }
+     */
+    @PostMapping("/publish")
+    public ResponseEntity<String> publishTestEvent(@RequestBody TestEventRequest request) {
+        diaryEventProducer.publishDiaryCreatedEvent(
+                request.diaryId(),
+                request.userId(),
+                request.petId(),
+                request.content(),
+                request.imageUrl()
+        );
+
+        return ResponseEntity.ok("Event published to Kafka!");
+    }
+
+    public record TestEventRequest(
+            Long diaryId,
+            Long userId,
+            Long petId,
+            String content,
+            String imageUrl
+    ) {}
+}

--- a/src/main/java/com/petlog/record/dto/DiaryEventMessage.java
+++ b/src/main/java/com/petlog/record/dto/DiaryEventMessage.java
@@ -1,65 +1,65 @@
-//package com.petlog.record.dto;
-//
-//import lombok.AllArgsConstructor;
-//import lombok.Builder;
-//import lombok.Data;
-//import lombok.NoArgsConstructor;
-//import java.time.LocalDateTime;
-//
-///**
-// * Diary Event Message (Kafka)
-// *
-// * Diary 생성/수정/삭제 이벤트를 Healthcare Service에 전달
-// *
-// * WHY 필요?
-// * - Healthcare Service가 RAG를 위해 Diary를 벡터화
-// * - Milvus Vector DB에 저장하여 Persona Chat에 사용
-// *
-// * @author diary-team
-// * @since 2025-12-23
-// */
-//@Data
-//@Builder
-//@NoArgsConstructor
-//@AllArgsConstructor
-//public class DiaryEventMessage {
-//
-//    /**
-//     * 이벤트 타입
-//     * - DIARY_CREATED: 다이어리 생성
-//     * - DIARY_UPDATED: 다이어리 수정
-//     * - DIARY_DELETED: 다이어리 삭제
-//     */
-//    private String eventType;
-//
-//    /**
-//     * Diary ID (Primary Key)
-//     */
-//    private Long diaryId;
-//
-//    /**
-//     * 사용자 ID
-//     */
-//    private Long userId;
-//
-//    /**
-//     * 반려동물 ID
-//     */
-//    private Long petId;
-//
-//    /**
-//     * Diary 내용 (AI 생성 또는 사용자 작성)
-//     * Healthcare Service가 이 내용을 벡터화
-//     */
-//    private String content;
-//
-//    /**
-//     * Diary 이미지 URL (S3)
-//     */
-//    private String imageUrl;
-//
-//    /**
-//     * Diary 생성 시간
-//     */
-//    private LocalDateTime createdAt;
-//}
+package com.petlog.record.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import java.time.LocalDateTime;
+
+/**
+ * Diary Event Message (Kafka)
+ *
+ * Diary 생성/수정/삭제 이벤트를 Healthcare Service에 전달
+ *
+ * WHY 필요?
+ * - Healthcare Service가 RAG를 위해 Diary를 벡터화
+ * - Milvus Vector DB에 저장하여 Persona Chat에 사용
+ *
+ * @author diary-team
+ * @since 2025-12-23
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class DiaryEventMessage {
+
+    /**
+     * 이벤트 타입
+     * - DIARY_CREATED: 다이어리 생성
+     * - DIARY_UPDATED: 다이어리 수정
+     * - DIARY_DELETED: 다이어리 삭제
+     */
+    private String eventType;
+
+    /**
+     * Diary ID (Primary Key)
+     */
+    private Long diaryId;
+
+    /**
+     * 사용자 ID
+     */
+    private Long userId;
+
+    /**
+     * 반려동물 ID
+     */
+    private Long petId;
+
+    /**
+     * Diary 내용 (AI 생성 또는 사용자 작성)
+     * Healthcare Service가 이 내용을 벡터화
+     */
+    private String content;
+
+    /**
+     * Diary 이미지 URL (S3)
+     */
+    private String imageUrl;
+
+    /**
+     * Diary 생성 시간
+     */
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/petlog/record/infrastructure/kafka/DiaryEventProducer.java
+++ b/src/main/java/com/petlog/record/infrastructure/kafka/DiaryEventProducer.java
@@ -1,112 +1,112 @@
-//package com.petlog.record.infrastructure.kafka;
-//
-//import com.petlog.record.dto.DiaryEventMessage;
-//import lombok.RequiredArgsConstructor;
-//import lombok.extern.slf4j.Slf4j;
-//import org.springframework.kafka.core.KafkaTemplate;
-//import org.springframework.kafka.support.SendResult;
-//import org.springframework.stereotype.Component;
-//import java.time.LocalDateTime;
-//import java.util.concurrent.CompletableFuture;
-//
-///**
-// * Diary Event Kafka Producer
-// *
-// * Diary 생성/수정/삭제 이벤트를 Healthcare Service로 발행
-// *
-// * @author diary-team
-// * @since 2025-12-23
-// */
-//@Slf4j
-//@Component
-//@RequiredArgsConstructor
-//public class DiaryEventProducer {
-//
-//    private final KafkaTemplate<String, Object> kafkaTemplate;
-//
-//    private static final String TOPIC = "diary-events";
-//
-//    /**
-//     * Diary 생성 이벤트 발행
-//     */
-//    public void publishDiaryCreatedEvent(
-//            Long diaryId,
-//            Long userId,
-//            Long petId,
-//            String content,
-//            String imageUrl
-//    ) {
-//        log.info("Publishing DIARY_CREATED event - diaryId: {}", diaryId);
-//
-//        DiaryEventMessage message = DiaryEventMessage.builder()
-//                .eventType("DIARY_CREATED")
-//                .diaryId(diaryId)
-//                .userId(userId)
-//                .petId(petId)
-//                .content(content)
-//                .imageUrl(imageUrl)
-//                .createdAt(LocalDateTime.now())
-//                .build();
-//
-//        // 비동기 발행
-//        CompletableFuture<SendResult<String, Object>> future =
-//                kafkaTemplate.send(TOPIC, userId.toString(), message);
-//
-//        // 콜백 처리
-//        future.whenComplete((result, ex) -> {
-//            if (ex == null) {
-//                log.info("✅ Event published successfully - diaryId: {}, partition: {}, offset: {}",
-//                        diaryId,
-//                        result.getRecordMetadata().partition(),
-//                        result.getRecordMetadata().offset());
-//            } else {
-//                log.error("❌ Failed to publish event - diaryId: {}", diaryId, ex);
-//                // TODO: 실패 시 DB에 실패 로그 저장 또는 재시도 큐에 추가
-//            }
-//        });
-//    }
-//
-//    /**
-//     * Diary 수정 이벤트 발행
-//     */
-//    public void publishDiaryUpdatedEvent(
-//            Long diaryId,
-//            Long userId,
-//            Long petId,
-//            String content
-//    ) {
-//        log.info("Publishing DIARY_UPDATED event - diaryId: {}", diaryId);
-//
-//        DiaryEventMessage message = DiaryEventMessage.builder()
-//                .eventType("DIARY_UPDATED")
-//                .diaryId(diaryId)
-//                .userId(userId)
-//                .petId(petId)
-//                .content(content)
-//                .createdAt(LocalDateTime.now())
-//                .build();
-//
-//        kafkaTemplate.send(TOPIC, userId.toString(), message);
-//    }
-//
-//    /**
-//     * Diary 삭제 이벤트 발행
-//     */
-//    public void publishDiaryDeletedEvent(
-//            Long diaryId,
-//            Long userId,
-//            Long petId
-//    ) {
-//        log.info("Publishing DIARY_DELETED event - diaryId: {}", diaryId);
-//
-//        DiaryEventMessage message = DiaryEventMessage.builder()
-//                .eventType("DIARY_DELETED")
-//                .diaryId(diaryId)
-//                .userId(userId)
-//                .petId(petId)
-//                .createdAt(LocalDateTime.now())
-//                .build();
-//
-//        kafkaTemplate.send(TOPIC, userId.toString(), message);
-//    }
-//}
+package com.petlog.record.infrastructure.kafka;
+
+import com.petlog.record.dto.DiaryEventMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
+import org.springframework.stereotype.Component;
+import java.time.LocalDateTime;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Diary Event Kafka Producer
+ *
+ * Diary 생성/수정/삭제 이벤트를 Healthcare Service로 발행
+ *
+ * @author diary-team
+ * @since 2025-12-23
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DiaryEventProducer {
+
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+
+    private static final String TOPIC = "diary-events";
+
+    /**
+     * Diary 생성 이벤트 발행
+     */
+    public void publishDiaryCreatedEvent(
+            Long diaryId,
+            Long userId,
+            Long petId,
+            String content,
+            String imageUrl
+    ) {
+        log.info("Publishing DIARY_CREATED event - diaryId: {}", diaryId);
+
+        DiaryEventMessage message = DiaryEventMessage.builder()
+                .eventType("DIARY_CREATED")
+                .diaryId(diaryId)
+                .userId(userId)
+                .petId(petId)
+                .content(content)
+                .imageUrl(imageUrl)
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        // 비동기 발행
+        CompletableFuture<SendResult<String, Object>> future =
+                kafkaTemplate.send(TOPIC, userId.toString(), message);
+
+        // 콜백 처리
+        future.whenComplete((result, ex) -> {
+            if (ex == null) {
+                log.info("✅ Event published successfully - diaryId: {}, partition: {}, offset: {}",
+                        diaryId,
+                        result.getRecordMetadata().partition(),
+                        result.getRecordMetadata().offset());
+            } else {
+                log.error("❌ Failed to publish event - diaryId: {}", diaryId, ex);
+                // TODO: 실패 시 DB에 실패 로그 저장 또는 재시도 큐에 추가
+            }
+        });
+    }
+
+    /**
+     * Diary 수정 이벤트 발행
+     */
+    public void publishDiaryUpdatedEvent(
+            Long diaryId,
+            Long userId,
+            Long petId,
+            String content
+    ) {
+        log.info("Publishing DIARY_UPDATED event - diaryId: {}", diaryId);
+
+        DiaryEventMessage message = DiaryEventMessage.builder()
+                .eventType("DIARY_UPDATED")
+                .diaryId(diaryId)
+                .userId(userId)
+                .petId(petId)
+                .content(content)
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        kafkaTemplate.send(TOPIC, userId.toString(), message);
+    }
+
+    /**
+     * Diary 삭제 이벤트 발행
+     */
+    public void publishDiaryDeletedEvent(
+            Long diaryId,
+            Long userId,
+            Long petId
+    ) {
+        log.info("Publishing DIARY_DELETED event - diaryId: {}", diaryId);
+
+        DiaryEventMessage message = DiaryEventMessage.builder()
+                .eventType("DIARY_DELETED")
+                .diaryId(diaryId)
+                .userId(userId)
+                .petId(petId)
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        kafkaTemplate.send(TOPIC, userId.toString(), message);
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -20,16 +20,20 @@ spring:
 
       # 신뢰성 설정
       acks: all  # 모든 replica가 확인할 때까지 대기
-      retries: 3  # 실패 시 3번 재시도
+      retries: 1  # 실패 시 3번 재시도
 
-      # 성능 설정
       properties:
-        linger.ms: 10  # 10ms 대기 후 배치 전송
-        batch.size: 16384  # 배치 크기 (16KB)
-        compression.type: snappy  # 압축 (빠른 성능)
+        # 중복 없는 전송(Idempotence) 활성화 (메시지 순서 보장 및 중복 방지)
+        enable.idempotence: true
 
-        # JSON 직렬화 설정
-        spring.json.add.type.headers: false  # __TypeId__ 헤더 제거
+        # ✅ 핵심 설정: 연결이 안 될 때 최대 1.5초만 기다리고 바로 에러를 뱉게 함
+        max.block.ms: 1500
+        # 요청 타임아웃 단축
+        request.timeout.ms: 3000
+
+        # JSON 직렬화 옵션
+        # 다른 서비스에서 역직렬화할 때 패키지 경로 문제를 방지하기 위해 헤더 정보 제거
+        spring.json.add.type.headers: false
 
   # ========================================
   # Spring AI 설정
@@ -79,6 +83,10 @@ spring:
             connectTimeout: 5000
             readTimeout: 5000
 
+# ========================================
+# 서버 및 모니터링 설정
+# ========================================
+
 # 서버 포트 (spring: 외부로 분리)
 server:
   port: 8087
@@ -89,7 +97,10 @@ logging:
     com.petlog.diary: DEBUG
     org.springframework.kafka: INFO
 
-# 외부 서비스 및 API 설정
+# ========================================
+# 외부 서비스 및 API 엔드포인트
+# ========================================
+
 openapi:
   service:
     url: ${API_GATEWAY}


### PR DESCRIPTION
# 관련 이슈
Closes #25

---

## 작업 내용
- Healthcare Service와의 실시간 데이터 동기화를 위해 Kafka를 도입하고, 다이어리 도메인의 변경 사항(생성/수정/삭제)을 이벤트로 발행하는 로직을 구현했습니다.

### 1. Kafka 인프라 및 환경 설정

- Docker Compose를 통한 Kafka Cluster(KRaft/Zookeeper) 환경 구축

- KafkaProducerConfig: 신뢰성(acks=all) 및 성능(snappy 압축)을 고려한 프로듀서 설정

- KafkaTopicConfig: 처리량 확장을 위해 diary-events 토픽의 파티션을 3개로 명시적 설정 (Canvas 참고)

### 2. 비동기 이벤트 발행 로직 구현

- DiaryEventProducer: 인프라 레이어에서 Kafka 메시지 전송 로직 추상화

- ApplicationEventPublisher & TransactionalEventListener: DB 트랜잭션 커밋 성공 시에만 이벤트를 발행하도록 설계

- @Async 적용: Kafka 브로커 장애나 지연이 메인 비즈니스 로직(일기 저장)을 차단(Blocking)하지 않도록 비동기 처리

### 3. 데이터 정합성 보장

- 사용자 ID를 메시지 키로 사용하여 특정 사용자의 일기 순서가 파티션 내에서 보장되도록 설정

---

## 테스트 결과

- [x] Kafka UI(8989 포트)를 통해 diary-events 토픽 내 파티션 3개 생성 및 데이터 분산 저장 확인

- [x] 카프카 브로커 중단 상태에서도 DB 저장이 정상적으로 완료되는지 비차단(Non-blocking) 테스트 완료

---

## 📸 스크린샷 (선택)
- 카프카 UI에서 파티션 3개 및 Offset 증가 확인 화면 
<img width="1104" height="108" alt="스크린샷 2025-12-29 오후 9 49 41" src="https://github.com/user-attachments/assets/defedaed-1899-401e-8f3a-2e936f4a284b" />
<img width="1187" height="281" alt="스크린샷 2025-12-29 오후 9 49 56" src="https://github.com/user-attachments/assets/3091bf70-0e7d-40f2-898e-1b1d9ac5ee5d" />

<img width="1054" height="108" alt="스크린샷 2025-12-30 오전 9 39 09" src="https://github.com/user-attachments/assets/f6fd7d81-1d06-4fe8-864d-2804a0ddb6ab" />

<img width="1052" height="437" alt="스크린샷 2025-12-29 오후 9 50 08" src="https://github.com/user-attachments/assets/299afeaf-7a39-4c38-a55c-16775df8e968" />
<img width="557" height="240" alt="스크린샷 2025-12-29 오후 9 45 23" src="https://github.com/user-attachments/assets/3a80fde0-fb3d-468d-8708-002b8f28e485" />




---

## 💬 리뷰 요구사항
- TransactionalEventListener와 Propagation.NOT_SUPPORTED 조합을 통해 트랜잭션 분리를 의도했는데, 전파 레벨 설정이 적절한지 검토 부탁드립니다.

- 현재 파티션 개수(3개)가 향후 확장성을 고려했을 때 적절한지 의견 공유 부탁드립니다.