### PR TITLE
 [Feat] Spring AI 기반 월간 리캡 자동 생성 기능 구현

### DIFF
--- a/src/main/java/com/petlog/record/controller/RecapController.java
+++ b/src/main/java/com/petlog/record/controller/RecapController.java
@@ -23,35 +23,35 @@ public class RecapController {
 
     private final RecapService recapService;
 
-    // 리캡 임시 생성
-    @Operation(summary = "리캡 생성", description = "특정 기간의 기록을 바탕으로 리캡을 생성하고 알림을 발송합니다.")
-    @PostMapping
-    public ResponseEntity<Map<String, Object>> createRecap(@Valid @RequestBody RecapRequest.Create request) {
-        Long recapId = recapService.createRecap(request);
+    // AI 리캡 자동 생성
+    @Operation(summary = "AI 월간 리캡 생성", description = "특정 기간의 일기 데이터를 AI가 분석하여 리캡을 자동으로 생성합니다.")
+    @PostMapping("/generate")
+    public ResponseEntity<Map<String, Object>> generateAiRecap(@Valid @RequestBody RecapRequest.Generate request) {
+        Long recapId = recapService.createAiRecap(request);
 
         Map<String, Object> response = new HashMap<>();
         response.put("recapId", recapId);
-        response.put("message", "리캡이 생성되었으며 알림이 발송되었습니다.");
+        response.put("message", "AI가 한 달간의 추억을 분석하여 리캡을 생성했습니다.");
 
         return ResponseEntity.created(URI.create("/api/recaps/" + recapId)).body(response);
     }
 
     // 상세 조회
-    @Operation(summary = "리캡 상세 조회", description = "리캡 ID를 통해 상세 내용을 조회합니다.")
+    @Operation(summary = "리캡 상세 조회", description = "리캡 ID를 통해 AI 분석 내용 및 하이라이트를 조회합니다.")
     @GetMapping("/{recapId}")
     public ResponseEntity<RecapResponse.Detail> getRecap(@PathVariable Long recapId) {
         return ResponseEntity.ok(recapService.getRecap(recapId));
     }
 
-    // 사용자별 전체 리캡 조회 (카드 리스트)
-    @Operation(summary = "사용자별 리캡 목록 조회", description = "특정 사용자의 모든 리캡 목록을 조회합니다.")
+    // 사용자별 전체 리캡 조회
+    @Operation(summary = "사용자별 리캡 목록 조회", description = "특정 사용자의 모든 월간 리캡 목록을 조회합니다.")
     @GetMapping("/user/{userId}")
     public ResponseEntity<List<RecapResponse.Simple>> getAllRecaps(@PathVariable Long userId) {
         return ResponseEntity.ok(recapService.getAllRecaps(userId));
     }
 
-    // 펫별 리캡 조회 (카드 리스트)
-    @Operation(summary = "펫별 리캡 목록 조회", description = "특정 펫의 리캡 목록을 조회합니다.")
+    // 펫별 리캡 조회
+    @Operation(summary = "펫별 리캡 목록 조회", description = "특정 펫의 월간 리캡 목록을 조회합니다.")
     @GetMapping("/pet/{petId}")
     public ResponseEntity<List<RecapResponse.Simple>> getRecapsByPet(@PathVariable Long petId) {
         return ResponseEntity.ok(recapService.getRecapsByPet(petId));

--- a/src/main/java/com/petlog/record/dto/request/RecapRequest.java
+++ b/src/main/java/com/petlog/record/dto/request/RecapRequest.java
@@ -15,12 +15,40 @@ import java.util.List;
 
 public class RecapRequest {
 
-    // [Request] 리캡 임시 생성
+    // [Request] AI 리캡 생성 요청 전용 DTO
     @Data
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
-    @Schema(name = "RecapCreateRequest", description = "리캡 생성 요청 DTO")
+    @Schema(name = "RecapGenerateRequest", description = "AI 리캡 생성 요청 DTO")
+    public static class Generate {
+
+        @NotNull(message = "펫 ID는 필수입니다.")
+        @Schema(description = "리캡을 생성할 펫 ID", example = "1")
+        private Long petId;
+
+        @NotNull(message = "사용자 ID는 필수입니다.")
+        @Schema(description = "사용자 ID", example = "1")
+        private Long userId;
+
+        @NotNull(message = "집계 기간 시작일은 필수입니다.")
+        @Schema(description = "집계 기간 시작일", example = "2024-03-01")
+        private LocalDate periodStart;
+
+        @NotNull(message = "집계 기간 종료일은 필수입니다.")
+        @Schema(description = "집계 기간 종료일", example = "2024-03-31")
+        private LocalDate periodEnd;
+
+        @Schema(description = "펫 이름 (AI 프롬프트 최적화용)", example = "초코")
+        private String petName;
+    }
+
+    // [Request] 리캡 생성 및 저장용 (기존 필드 및 로직 유지)
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(name = "RecapCreateRequest", description = "리캡 생성 및 저장 요청 DTO")
     public static class Create {
 
         @NotNull(message = "펫 ID는 필수입니다.")
@@ -49,7 +77,6 @@ public class RecapRequest {
         @Schema(description = "포함된 추억(일기) 개수", example = "15")
         private Integer momentCount;
 
-        // 하이라이트 목록
         @Schema(description = "리캡 하이라이트 목록")
         private List<HighlightDto> highlights;
 
@@ -64,14 +91,13 @@ public class RecapRequest {
                     .periodEnd(this.periodEnd)
                     .mainImageUrl(this.mainImageUrl)
                     .momentCount(this.momentCount)
-                    .status(RecapStatus.GENERATED) // 기본 상태 설정
+                    .status(RecapStatus.GENERATED)
                     .build();
 
-            // 하이라이트 리스트가 있다면 Entity로 변환하여 추가
             if (this.highlights != null) {
                 this.highlights.stream()
                         .map(HighlightDto::toEntity)
-                        .forEach(recap::addHighlight); // Recap의 연관관계 편의 메서드 사용
+                        .forEach(recap::addHighlight);
             }
 
             return recap;
@@ -91,7 +117,6 @@ public class RecapRequest {
         @Schema(description = "하이라이트 내용", example = "처음으로 강아지 친구를 만났어요.")
         private String content;
 
-        // DTO -> Entity 변환
         public RecapHighlight toEntity() {
             return RecapHighlight.builder()
                     .title(this.title)

--- a/src/main/java/com/petlog/record/dto/response/RecapAiResponse.java
+++ b/src/main/java/com/petlog/record/dto/response/RecapAiResponse.java
@@ -1,0 +1,39 @@
+package com.petlog.record.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "AI 분석 결과 데이터 (내부용)")
+public class RecapAiResponse {
+
+    @Schema(description = "AI가 생성한 리캡 제목", example = "초코와 함께한 따스한 3월")
+    private String title;
+
+    @Schema(description = "AI가 분석한 한 달 요약 총평", example = "이번 달 초코는 새로운 친구들을 많이 만나며 사회성이 부쩍 좋아진 한 달을 보냈어요.")
+    private String summary;
+
+    @Schema(description = "AI가 선정한 이번 달의 주요 하이라이트 목록")
+    private List<HighlightInfo> highlights;
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "AI 분석 하이라이트 세부 정보")
+    public static class HighlightInfo {
+        @Schema(description = "하이라이트 소제목", example = "한강 공원에서의 첫 질주")
+        private String title;
+
+        @Schema(description = "하이라이트 상세 내용", example = "처음으로 리드줄 없이 운동장을 뛰어놀며 무척 행복해 보였던 날입니다.")
+        private String content;
+    }
+}

--- a/src/main/java/com/petlog/record/dto/response/RecapResponse.java
+++ b/src/main/java/com/petlog/record/dto/response/RecapResponse.java
@@ -28,10 +28,10 @@ public class RecapResponse {
         @Schema(description = "펫 ID", example = "1")
         private Long petId;
 
-        @Schema(description = "리캡 제목", example = "2024년 3월의 소중한 기록")
+        @Schema(description = "리캡 제목 (AI 생성)", example = "2024년 3월의 소중한 기록")
         private String title;
 
-        @Schema(description = "리캡 요약 문구", example = "봄바람을 맞으며 산책하는 것을 가장 좋아했어요.")
+        @Schema(description = "리캡 요약 문구 (AI 생성)", example = "봄바람을 맞으며 산책하는 것을 가장 좋아했어요.")
         private String summary;
 
         @Schema(description = "집계 기간 시작일", example = "2024-03-01")
@@ -40,26 +40,14 @@ public class RecapResponse {
         @Schema(description = "집계 기간 종료일", example = "2024-03-31")
         private LocalDate periodEnd;
 
-        @Schema(description = "대표 이미지 URL", example = "https://bucket.s3.region.amazonaws.com/cover.jpg")
+        @Schema(description = "대표 이미지 URL (기존 일기 중 선정되거나 기본 이미지)", example = "https://bucket.s3.region.amazonaws.com/cover.jpg")
         private String mainImageUrl;
 
-        @Schema(description = "포함된 추억(일기) 개수", example = "15")
+        @Schema(description = "분석에 포함된 추억(일기) 개수", example = "15")
         private Integer momentCount;
 
-        @Schema(description = "생성 상태 (GENERATED, COMPLETED 등)", example = "COMPLETED")
+        @Schema(description = "생성 상태 (GENERATED, WAITING)", example = "GENERATED")
         private String status;
-
-        @Schema(description = "기간 내 평균 심박수 (BPM)", example = "85")
-        private Integer avgHeartRate;
-
-        @Schema(description = "기간 내 일평균 걸음 수", example = "5400")
-        private Integer avgStepCount;
-
-        @Schema(description = "기간 내 일평균 수면 시간 (시간)", example = "12.5")
-        private Double avgSleepTime;
-
-        @Schema(description = "기간 내 평균 몸무게 (kg)", example = "5.2")
-        private Double avgWeight;
 
         @Schema(description = "생성 일시")
         private LocalDateTime createdAt;
@@ -67,7 +55,7 @@ public class RecapResponse {
         @Schema(description = "수정 일시")
         private LocalDateTime updatedAt;
 
-        @Schema(description = "리캡 하이라이트 목록")
+        @Schema(description = "리캡 하이라이트 목록 (AI 분석 결과)")
         private List<Highlight> highlights;
 
         // Entity -> DTO 변환 (Factory Method)
@@ -82,7 +70,6 @@ public class RecapResponse {
                     .mainImageUrl(recap.getMainImageUrl())
                     .momentCount(recap.getMomentCount())
                     .status(recap.getStatus().name())
-                    // 건강 데이터는 Service에서 주입하므로 여기선 skip
                     .createdAt(recap.getCreatedAt())
                     .updatedAt(recap.getUpdatedAt())
                     .highlights(recap.getHighlights().stream()
@@ -111,7 +98,7 @@ public class RecapResponse {
         @Schema(description = "추억 개수", example = "15")
         private Integer momentCount;
 
-        @Schema(description = "상태", example = "COMPLETED")
+        @Schema(description = "상태", example = "GENERATED")
         private String status;
 
         @Schema(description = "시작일", example = "2024-03-01")

--- a/src/main/java/com/petlog/record/repository/jpa/DiaryRepository.java
+++ b/src/main/java/com/petlog/record/repository/jpa/DiaryRepository.java
@@ -4,6 +4,7 @@ import com.petlog.record.entity.Diary;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Repository
@@ -13,4 +14,7 @@ public interface DiaryRepository extends JpaRepository<Diary, Long> {
 
     // 특정 펫에 대해 작성된 모든 일기 목록 조회
     List<Diary> findAllByPetId(Long petId);
+
+    // AI 리캡 조회를 위해 추가 (필드명이 date일 경우)
+    List<Diary> findAllByPetIdAndDateBetween(Long petId, LocalDate start, LocalDate end);
 }

--- a/src/main/java/com/petlog/record/service/RecapAiService.java
+++ b/src/main/java/com/petlog/record/service/RecapAiService.java
@@ -1,0 +1,16 @@
+package com.petlog.record.service;
+
+import com.petlog.record.dto.response.RecapAiResponse;
+import java.util.List;
+
+public interface RecapAiService {
+    /**
+     * 반려동물의 이름과 일기 내용들을 바탕으로 한 달 리캡 데이터를 생성합니다.
+     */
+//    RecapAiResponse analyzeMonth(String petName, List<String> diaryEntries);
+
+    /**
+     * 특정 연도/월 정보를 포함하여 일기 내용을 분석합니다.
+     */
+    RecapAiResponse analyzeMonth(String petName, int year, int month, List<String> diaryEntries);
+}

--- a/src/main/java/com/petlog/record/service/RecapService.java
+++ b/src/main/java/com/petlog/record/service/RecapService.java
@@ -2,19 +2,17 @@ package com.petlog.record.service;
 
 import com.petlog.record.dto.request.RecapRequest;
 import com.petlog.record.dto.response.RecapResponse;
-
 import java.util.List;
 
 public interface RecapService {
-    // 리캡 생성
-    Long createRecap(RecapRequest.Create request);
+    /**
+     * AI를 활용하여 월간 리캡을 생성합니다.
+     */
+    Long createAiRecap(RecapRequest.Generate request);
 
-    // 상세 조회
     RecapResponse.Detail getRecap(Long recapId);
 
-    // 사용자별 리캡 전체 목록 조회
     List<RecapResponse.Simple> getAllRecaps(Long userId);
 
-    // [추가] 펫별 리캡 목록 조회
     List<RecapResponse.Simple> getRecapsByPet(Long petId);
 }

--- a/src/main/java/com/petlog/record/service/impl/RecapAiServiceImpl.java
+++ b/src/main/java/com/petlog/record/service/impl/RecapAiServiceImpl.java
@@ -1,0 +1,51 @@
+package com.petlog.record.service.impl;
+
+import com.petlog.record.dto.response.RecapAiResponse;
+import com.petlog.record.service.RecapAiService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.chat.prompt.PromptTemplate;
+import org.springframework.ai.converter.BeanOutputConverter;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class RecapAiServiceImpl implements RecapAiService {
+
+    private final ChatModel chatModel;
+
+    @Override
+    public RecapAiResponse analyzeMonth(String petName, int year, int month, List<String> diaryEntries) {
+        BeanOutputConverter<RecapAiResponse> converter = new BeanOutputConverter<>(RecapAiResponse.class);
+
+        String userPromptText = """
+                반려동물 {petName}의 {year}년 {month}월 일기 기록들입니다:
+                {diaries}
+                
+                위 기록들을 바탕으로 이번 달의 '월간 리캡'을 작성해주세요.
+                
+                [작성 지침]
+                1. 제목(title): 반드시 {year}년 {month}월이라는 구체적인 숫자를 포함하여 '2024년 3월의 소중한 기록'과 같은 스타일로 지어주세요. (202X년 X월과 같은 플레이스홀더를 사용하지 마세요.)
+                2. 요약(summary): 전체적인 일기 내용을 분석하여 보호자에게 보내는 편지 형식으로 따뜻하게 작성해주세요.
+                3. 하이라이트(highlights): 가장 인상 깊은 사건 3가지를 선정해 제목과 요약을 작성해주세요.
+                
+                {format}
+                """;
+
+        PromptTemplate promptTemplate = new PromptTemplate(userPromptText);
+        Prompt prompt = promptTemplate.create(Map.of(
+                "petName", petName,
+                "year", year,
+                "month", month,
+                "diaries", String.join("\n---\n", diaryEntries),
+                "format", converter.getFormat()
+        ));
+
+        var response = chatModel.call(prompt);
+        return converter.convert(response.getResult().getOutput().getContent());
+    }
+}


### PR DESCRIPTION
# 관련 이슈

Closes #26 

---

# 작업 내용

## 1. Spring AI (OpenAI) 연동 분석 로직 구현

- 특정 기간의 일기 데이터를 RDB에서 조회하여 AI에게 전달하고, 한 달간의 추억을 요약하는 기능을 구현했습니다.

- RecapAiService를 통해 구조화된 응답(Structured Output)을 받아 title, summary, highlights 데이터를 생성합니다.

## 2. 데이터 기반 동적 리캡 생성

- 요청받은 periodStart 정보를 바탕으로 연도와 월을 추출하여 AI 프롬프트에 주입함으로써 정확한 시점의 리캡을 생성하도록 개선했습니다.

- RecapHighlight 엔티티와의 연관관계를 통해 AI가 선정한 3가지 주요 하이라이트를 자동으로 저장합니다.

## 3. DTO 및 서비스 아키텍처 정립

- AI 생성 전용 DTO (RecapRequest.Generate)를 도입하여 확장성을 고려했습니다.

- 기존의 수동 조회 기능(getRecap, getAllRecaps 등)과 AI 생성 로직을 통합했습니다.

---

# 작업 상세

- RecapServiceImpl: 일기 데이터 필터링 및 AI 분석 결과 엔티티 변환 로직 담당.

- RecapAiServiceImpl: Spring AI ChatModel을 이용한 프롬프트 엔지니어링 및 JSON 응답 변환 담당.

- DiaryRepository: 기간별 일기 조회를 위한 findAllByPetIdAndDateBetween 쿼리 메서드 추가.

---

# 테스트 결과

- [x] Postman 테스트 완료 (특정 기간 일기 존재 시 리캡 ID 반환 확인)

- [x] AI 응답 파싱 및 DB 저장 테스트 완료

- [x] 일기 데이터 부재 시 예외 처리 테스트 완료

---

# 📸 스크린샷 


<img width="819" height="474" alt="스크린샷 2026-01-02 오후 6 24 45" src="https://github.com/user-attachments/assets/64452e26-be73-43cf-8d83-90cd5b0e593c" />
<img width="818" height="700" alt="스크린샷 2026-01-02 오후 6 24 59" src="https://github.com/user-attachments/assets/4a3ffc39-057f-490e-b767-2d120f8e9802" />

<img width="952" height="391" alt="스크린샷 2026-01-02 오후 6 44 28" src="https://github.com/user-attachments/assets/71853053-63fe-4ef4-8b66-e40071e841c5" />

<img width="947" height="416" alt="스크린샷 2026-01-02 오후 6 44 41" src="https://github.com/user-attachments/assets/14867a9c-7537-4efa-92d9-14ccfe8b4a39" />


---


# 💬 리뷰 요구사항

- AI 프롬프트 내용 중 반려동물의 관점에서 작성하도록 지시한 부분이 자연스럽게 출력되는지 확인 부탁드립니다.

- 현재 일기가 1개만 있어도 생성이 가능하도록 설계했는데, 최소 개수 제한이 필요한지에 대한 의견 주시면 감사하겠습니다.