### PR TITLE
[Feat] 리캡 생성 시 30 코인 자동 적립

### DIFF
--- a/src/main/java/com/petlog/record/client/UserClient.java
+++ b/src/main/java/com/petlog/record/client/UserClient.java
@@ -4,6 +4,10 @@ import com.petlog.record.dto.client.UserClientResponse;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import java.util.Map;
 
 // User Service 호출
 @FeignClient(name = "user-service", url = "${external.user-service.url}")
@@ -20,4 +24,10 @@ public interface UserClient {
      */
     @GetMapping("/api/users/{userId}")
     UserClientResponse getUserInfo(@PathVariable("userId") Long userId);
+
+    /**
+     * 코인 적립
+     */
+    @PostMapping("/api/users/{userId}/coin/earn")
+    void earnCoin(@PathVariable("userId") Long userId, @RequestBody Map<String, Object> request);
 }

--- a/src/main/java/com/petlog/record/service/impl/RecapServiceImpl.java
+++ b/src/main/java/com/petlog/record/service/impl/RecapServiceImpl.java
@@ -1,6 +1,7 @@
 package com.petlog.record.service.impl;
 
 import com.petlog.record.client.NotificationClient;
+import com.petlog.record.client.UserClient;
 import com.petlog.record.dto.client.NotificationRequest;
 import com.petlog.record.dto.request.RecapRequest;
 import com.petlog.record.dto.response.RecapAiResponse;
@@ -22,9 +23,7 @@ import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Objects;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -37,6 +36,7 @@ public class RecapServiceImpl implements RecapService {
     private final DiaryRepository diaryRepository;
     private final RecapAiService recapAiService;
     private final NotificationClient notificationClient; // 리캡 알림 연동
+    private final UserClient userClient;  // 리캡 코인 연동
 
     @Override
     @Transactional
@@ -110,6 +110,18 @@ public class RecapServiceImpl implements RecapService {
         Recap savedRecap = recapRepository.save(recap);
         log.info("[Recap] AI 리캡 저장 완료 - Recap ID: {}", savedRecap.getRecapId());
 
+        // ✅ [NEW] 코인 적립 (30 코인)
+        try {
+            Map<String, Object> coinRequest = new HashMap<>();
+            coinRequest.put("amount", 30L);
+            coinRequest.put("type", "WRITERECAP");
+
+            userClient.earnCoin(request.getUserId(), coinRequest);
+            log.info("[Coin] 리캡 생성 코인 적립 완료: userId={}, amount=30", request.getUserId());
+        } catch (Exception e) {
+            log.error("[Coin] 코인 적립 실패 (리캡은 정상 생성됨): {}", e.getMessage());
+        }
+
         // ✅ [추가] 리캡 생성 알림 전송
         try {
             NotificationRequest notificationRequest = NotificationRequest.builder()
@@ -117,6 +129,7 @@ public class RecapServiceImpl implements RecapService {
                     .senderId(request.getUserId())
                     .receiverId(request.getUserId())
                     .targetId(savedRecap.getRecapId())
+                    .coin(30L)
                     .build();
 
             notificationClient.createNotification(notificationRequest);


### PR DESCRIPTION
## 📝 작업 내용

### ✅ 리캡 생성 코인 적립 시스템 구현
- **RecapServiceImpl.createAiRecap()** 메서드에 코인 적립 로직 추가
- 리캡 생성 성공 시 **30 코인** 자동 적립
- **UserClient** Feign Client 활용한 유저 서비스 API 호출

### 🔧 구현 세부사항
- 리캡 저장 성공 → `UserClient.earnCoin(userId, 30, "WRITERECAP")` 호출
- 자동 예약 리캡 및 수동 생성 리캡 모두 적용
- 알림에 코인 정보 포함 (`coin: 30L`)

### 🛡️ 에러 핸들링
- 코인 적립 실패해도 리캡 생성은 정상 처리
- try-catch 블록으로 트랜잭션 안전성 보장
- 상세 로그 기록으로 디버깅 지원

---

## 📸 스크린샷
<img width="159" height="51" alt="스크린샷 2026-01-05 오후 8 37 03" src="https://github.com/user-attachments/assets/aa2203fa-e32d-4b55-ba4f-3c12f27e8dbc" />
<img width="352" height="49" alt="스크린샷 2026-01-05 오후 8 38 47" src="https://github.com/user-attachments/assets/6a1bf423-a2c3-49c4-96ec-225098c76f24" />


*리캡 생성 완료 시 알림 수신 화면*

---

## ✅ 테스트 결과

- [x] 자동 리캡 생성 → 30 코인 적립 확인
- [x] 수동 리캡 생성 → 30 코인 적립 확인
- [x] 코인 적립 실패 시 리캡 정상 생성 확인
- [x] 알림에 "펫코인 30원이 적립되었습니다" 표시 확인

---

## 📂 변경 파일

### Backend (Diary Service)
- **RecapServiceImpl.java** - 코인 적립 로직 추가
  - UserClient 필드 의존성 주입
  - createAiRecap() 메서드에 코인 적립 및 알림 전송

### 기존 파일 활용
- **UserClient.java** - Feign Client (기존)

---

## 💰 보상 정책

| 활동 | 코인 | 비고 |
|------|------|------|
| 일기 생성 | 15 코인 | 매일 작성 권장 |
| **리캡 생성** | **30 코인** ⭐ | 월간 회고 |
| 소셜 피드 공유 | 10 코인 | 추가 보너스 |

---

## 💬 리뷰 포인트

- UserClient 의존성 주입이 올바른가?
- 코인 적립 실패 시 에러 핸들링이 안전한가?
- 30 코인 보상이 적절한가?
- 자동/수동 생성 모두 코인 지급이 정상 작동하는가?